### PR TITLE
Refactor global Engine/Editor singletons

### DIFF
--- a/ScarletEditor/include/Editor.h
+++ b/ScarletEditor/include/Editor.h
@@ -17,9 +17,9 @@ namespace ScarletEngine
 	{
 	public:
 		Editor();
+		virtual ~Editor() {}
 
 		virtual void Initialize() override;
-
 		virtual void Tick(double DeltaTime) override;
 
 		void SetSelection(const SharedPtr<Entity>& InSelectedEntity)
@@ -36,8 +36,6 @@ namespace ScarletEngine
 
 		const OnSelectionChangedEvent& GetOnSelectionChanged() const { return OnSelectionChanged; }
 		const OnSelectionClearedEvent& GetOnSelectionCleared() const { return OnSelectionCleared; }
-
-		static Editor& Get() { static Editor Instance; return Instance; }
 	private:
 		void DrawUI();
 	private:
@@ -71,4 +69,6 @@ namespace ScarletEngine
 		OnSelectionChangedEvent OnSelectionChanged;
 		OnSelectionClearedEvent OnSelectionCleared;
 	};
+
+	extern UniquePtr<Editor> GEditor;
 }

--- a/ScarletEditor/src/Editor.cpp
+++ b/ScarletEditor/src/Editor.cpp
@@ -8,6 +8,8 @@
 
 namespace ScarletEngine
 {
+	UniquePtr<Editor> GEditor = nullptr;
+
 	Editor::Editor()
 		: FrameTimes()
 		, EditorWorld(nullptr)
@@ -97,7 +99,7 @@ namespace ScarletEngine
 			{
 				if (ImGui::MenuItem("Exit"))
 				{
-					Engine::Get().SignalQuit();
+					GEngine->SignalQuit();
 				}
 				ImGui::EndMenu();
 			}

--- a/ScarletEditor/src/EditorMain.cpp
+++ b/ScarletEditor/src/EditorMain.cpp
@@ -5,12 +5,17 @@ int main()
 {
 	using namespace ScarletEngine;
 
-	Engine& GEngine = Engine::Get();
-	GEngine.Initialize();
+	GEngine = MakeUnique<Engine>();
+	GEngine->Initialize();
 
 	// initialize the global editor
-	Editor::Get();
-	GEngine.Run();
+	GEditor = MakeUnique<Editor>();
+
+	GEngine->Run();
+
+	GEditor.reset();
+	GEngine->Terminate();
+	GEngine.reset();
 
 	return 0;
 }

--- a/ScarletEditor/src/Panels/PropertyEditor.cpp
+++ b/ScarletEditor/src/Panels/PropertyEditor.cpp
@@ -9,8 +9,8 @@ namespace ScarletEngine
 		: FocusedEntity()
 		, bHasSelection(false)
 	{
-		Editor::Get().GetOnSelectionChanged().Bind(this, &PropertyEditorPanel::OnSelectionChanged);
-		Editor::Get().GetOnSelectionCleared().Bind(this, &PropertyEditorPanel::OnSelectionCleared);
+		GEditor->GetOnSelectionChanged().Bind(this, &PropertyEditorPanel::OnSelectionChanged);
+		GEditor->GetOnSelectionCleared().Bind(this, &PropertyEditorPanel::OnSelectionCleared);
 	}
 
 	void PropertyEditorPanel::Draw()

--- a/ScarletEditor/src/Panels/SceneHierarchy/SceneHierarchy.cpp
+++ b/ScarletEditor/src/Panels/SceneHierarchy/SceneHierarchy.cpp
@@ -16,7 +16,7 @@ namespace ScarletEngine
 		: RepresentingWorld(InRepresentingWorld)
 	{
 		RepresentingWorld.lock()->GetOnEntityAddedToWorldEvent().Bind(this, &SceneHierarchyPanel::OnEntityAddedToWorld);
-		Editor::Get().GetOnSelectionChanged().Bind(this, &SceneHierarchyPanel::OnWorldSelectionChanged);
+		GEditor->GetOnSelectionChanged().Bind(this, &SceneHierarchyPanel::OnWorldSelectionChanged);
 		RepopulateItems();
 	}
 
@@ -44,7 +44,7 @@ namespace ScarletEngine
 				if (ImGui::IsItemClicked() && !bIsAlreadySelected)
 				{
 					EntItem->bIsSelected = true;
-					Editor::Get().SetSelection(EntItem->Ent.lock());
+					GEditor->SetSelection(EntItem->Ent.lock());
 				}
 
 				if (bNodeOpen)
@@ -59,7 +59,7 @@ namespace ScarletEngine
 				if (ImGui::IsItemClicked() && !bIsAlreadySelected)
 				{
 					EntItem->bIsSelected = true;
-					Editor::Get().SetSelection(EntItem->Ent.lock());
+					GEditor->SetSelection(EntItem->Ent.lock());
 				}
 			}
 

--- a/ScarletEngine/include/Core/Core.h
+++ b/ScarletEngine/include/Core/Core.h
@@ -11,3 +11,8 @@
 
 // Core component types
 #include "Transform.h"
+
+namespace ScarletEngine
+{
+	extern UniquePtr<Engine> GEngine;
+}

--- a/ScarletEngine/include/Core/Engine.h
+++ b/ScarletEngine/include/Core/Engine.h
@@ -9,6 +9,8 @@ namespace ScarletEngine
 	class Engine
 	{
 	public:
+		Engine();
+
 		void Initialize();
 		void Run();
 
@@ -24,10 +26,8 @@ namespace ScarletEngine
 		/** Remove a tickable object. This must be immediate as it will only be called on destruction of an ITickable */
 		void RemoveTickable(ITickable* TickableObject);
 
-		/** Return a reference to the global Engine object */
-		static Engine& Get() { static Engine Instance; return Instance; }
-	private:
 		void Terminate();
+	private:
 
 		/** Called before objects are ticked each frame */
 		void PreUpdate();
@@ -38,8 +38,7 @@ namespace ScarletEngine
 		void AddQueuedTickables();
 		void AddTickable(ITickable* TickableToAdd);
 	private:
-		// Prevent instantiations of this class and disable copy/move constructors
-		Engine();
+		// Prevent disable copy/move constructors
 		Engine(const Engine&) = delete;
 		Engine(Engine&&) = delete;
 		
@@ -61,4 +60,6 @@ namespace ScarletEngine
 		/** True when the engine is in the middle of ticking objects */
 		uint32_t bTickingObjects : 1;
 	};
+
+	extern UniquePtr<Engine> GEngine;
 }

--- a/ScarletEngine/include/Core/ITickable.h
+++ b/ScarletEngine/include/Core/ITickable.h
@@ -16,6 +16,8 @@ namespace ScarletEngine
 
 		virtual void Tick(double DeltaTime) = 0;
 
+		virtual void Terminate() {}
+
 		/** Override if object wants a fixed timestep rather than variable */
 		virtual bool WantsFixedTimestep() const { return false; }
 	};

--- a/ScarletEngine/include/Core/Memory/Memory.h
+++ b/ScarletEngine/include/Core/Memory/Memory.h
@@ -67,4 +67,10 @@ namespace ScarletEngine
 	{
 		return SharedPtr<T>(GlobalAllocator<T>::New(std::forward<Args>(args)...), typename GlobalAllocator<T>::Delete());
 	}
+
+	template <typename T, typename... Args>
+	[[nodiscard]] UniquePtr<T> MakeUnique(Args&&... args)
+	{
+		return UniquePtr<T>(GlobalAllocator<T>::New(std::forward<Args>(args)...));
+	}
 }

--- a/ScarletEngine/src/Core/Engine.cpp
+++ b/ScarletEngine/src/Core/Engine.cpp
@@ -17,6 +17,8 @@
 
 namespace ScarletEngine
 {
+	UniquePtr<Engine> GEngine = nullptr;
+
 	Engine::Engine()
 		: VariableUpdateTickables()
 		, FixedUpdateTickables()
@@ -163,8 +165,6 @@ namespace ScarletEngine
 			// Process anything that should happen before the next update
 			PostUpdate();
 		}
-
-		Terminate();
 	}
 
 	void Engine::PreUpdate()

--- a/ScarletEngine/src/Core/ITickable.cpp
+++ b/ScarletEngine/src/Core/ITickable.cpp
@@ -6,15 +6,11 @@ namespace ScarletEngine
 {
 	ITickable::ITickable()
 	{
-		Engine& GEngine = Engine::Get();
-
-		GEngine.QueueAddTickable(this);
+		GEngine->QueueAddTickable(this);
 	}
 
 	ITickable::~ITickable()
 	{
-		Engine& GEngine = Engine::Get();
-
-		GEngine.RemoveTickable(this);
+		GEngine->RemoveTickable(this);
 	}
 }

--- a/ScarletEngine/src/OpenGLRAL/OpenGLRAL.cpp
+++ b/ScarletEngine/src/OpenGLRAL/OpenGLRAL.cpp
@@ -16,7 +16,7 @@ namespace ScarletEngine
 
 	void WindowCloseCallback(GLFWwindow*)
 	{
-		Engine::Get().SignalQuit();
+		GEngine->SignalQuit();
 	}
 
 	void OpenGLRAL::Initialize()


### PR DESCRIPTION
Refactored the way the singletons are managed. No longer using reference to static function local variable so that we can control the lifetime of these objects using a global pointer.