### PR TITLE
Implemented an Output Log editor panel

### DIFF
--- a/ScarletEditor/config/default_imgui.ini
+++ b/ScarletEditor/config/default_imgui.ini
@@ -1,6 +1,6 @@
 [Window][DockSpace]
 Pos=0,0
-Size=2115,1072
+Size=1920,1109
 Collapsed=0
 
 [Window][Debug##Default]
@@ -21,43 +21,51 @@ Collapsed=0
 DockId=0x00000005,0
 
 [Window][Property Editor]
-Pos=1506,42
-Size=609,1030
+Pos=1616,33
+Size=304,1076
 Collapsed=0
 DockId=0x00000002,1
 
 [Window][Dear ImGui Demo]
-Pos=1506,42
-Size=609,1030
+Pos=1616,33
+Size=304,1076
 Collapsed=0
 DockId=0x00000002,0
 
 [Window][Stats]
-Pos=0,457
-Size=395,615
+Pos=0,466
+Size=358,643
 Collapsed=0
 DockId=0x00000008,0
 
 [Window][ Viewport##0]
-Pos=397,42
-Size=1107,1030
+Pos=360,33
+Size=1254,743
 Collapsed=0
-DockId=0x00000001,0
+DockId=0x00000009,0
 
 [Window][ Scene Hierarchy]
-Pos=0,42
-Size=395,413
+Pos=0,33
+Size=358,431
 Collapsed=0
 DockId=0x00000007,0
 
+[Window][Output Log]
+Pos=360,778
+Size=1254,331
+Collapsed=0
+DockId=0x0000000A,0
+
 [Docking][Data]
-DockSpace       ID=0x3FC20BEE Window=0x9A404470 Pos=0,42 Size=2115,1030 Split=X
+DockSpace       ID=0x3FC20BEE Window=0x9A404470 Pos=0,33 Size=1920,1076 Split=X
   DockNode      ID=0x00000003 Parent=0x3FC20BEE SizeRef=149,2033 Split=Y Selected=0x9A68760C
     DockNode    ID=0x00000005 Parent=0x00000003 SizeRef=285,1674 Selected=0x9A68760C
     DockNode    ID=0x00000006 Parent=0x00000003 SizeRef=285,357 Split=Y Selected=0x968648AE
       DockNode  ID=0x00000007 Parent=0x00000006 SizeRef=395,413 Selected=0x43E91363
       DockNode  ID=0x00000008 Parent=0x00000006 SizeRef=395,615 Selected=0x968648AE
   DockNode      ID=0x00000004 Parent=0x3FC20BEE SizeRef=649,2033 Split=X
-    DockNode    ID=0x00000001 Parent=0x00000004 SizeRef=2510,2033 CentralNode=1 Selected=0x467A53AC
+    DockNode    ID=0x00000001 Parent=0x00000004 SizeRef=2510,2033 Split=Y Selected=0x467A53AC
+      DockNode  ID=0x00000009 Parent=0x00000001 SizeRef=949,743 CentralNode=1 Selected=0x467A53AC
+      DockNode  ID=0x0000000A Parent=0x00000001 SizeRef=949,331 Selected=0x4DC17FF4
     DockNode    ID=0x00000002 Parent=0x00000004 SizeRef=609,2033 Selected=0xE927CF2F
 

--- a/ScarletEditor/include/Editor.h
+++ b/ScarletEditor/include/Editor.h
@@ -5,6 +5,7 @@
 #include "Renderer/Viewport.h"
 #include "Panels/SceneHierarchy/SceneHierarchy.h"
 #include "Panels/PropertyEditor.h"
+#include "Panels/OutputLog.h"
 #include "AssetManager/AssetHandle.h"
 #include "RAL/RALResources.h"
 
@@ -68,6 +69,7 @@ namespace ScarletEngine
 		
 		SharedPtr<SceneHierarchyPanel> SceneHierarchy;
 		SharedPtr<PropertyEditorPanel> PropertyEditor;
+		SharedPtr<OutputLogPanel> OutputLog;
 
 		Set<Entity*> SelectedEntities;
 

--- a/ScarletEditor/include/Panels/OutputLog.h
+++ b/ScarletEditor/include/Panels/OutputLog.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "Core/Core.h"
+
+namespace ScarletEngine
+{
+	struct Message
+	{
+		String Text;
+		LogLevel Severity;
+	};
+
+	class OutputLogPanel
+	{
+	public:
+		OutputLogPanel();
+		~OutputLogPanel();
+
+		void Draw();
+	private:
+		bool PassesFilter(const String& Msg) const;
+
+		void OnMessageLogged(LogLevel Level, const char* Msg);
+
+		void Clear();
+	private:
+		String FilterText;
+		Array<Message> MessageBuffer;
+
+		const uint32_t MaxBufferLength = 1024;
+		uint32_t CurrentMessageIndex;
+		uint32_t NumMessages;
+
+		bool bHasNewMessage = false;
+		bool bAutoscroll = true;
+
+		bool bShowVerbose = false;
+		bool bShowInfo = true;
+		bool bShowWarning = true;
+		bool bShowError = true;
+	};
+}

--- a/ScarletEditor/src/Editor.cpp
+++ b/ScarletEditor/src/Editor.cpp
@@ -15,6 +15,7 @@ namespace ScarletEngine
 		, EditorWorld(nullptr)
 		, SceneHierarchy(nullptr)
 		, PropertyEditor(nullptr)
+		, OutputLog(nullptr)
 		, SelectedEntities()
 	{
 	}
@@ -24,6 +25,7 @@ namespace ScarletEngine
 		EditorWorld = MakeShared<World>();
 		SceneHierarchy = MakeShared<SceneHierarchyPanel>(EditorWorld);
 		PropertyEditor = MakeShared<PropertyEditorPanel>();
+		OutputLog = MakeShared<OutputLogPanel>();
 
 		// Test entities
 		EditorWorld->CreateEntity<Transform>("Entity 1");
@@ -153,6 +155,7 @@ namespace ScarletEngine
 
 		SceneHierarchy->Draw();
 		PropertyEditor->Draw();
+		OutputLog->Draw();
 
 		ImGui::Begin("Stats");
 		ImGui::Text("CPU");

--- a/ScarletEditor/src/EditorMain.cpp
+++ b/ScarletEditor/src/EditorMain.cpp
@@ -17,5 +17,7 @@ int main()
 	GEngine->Terminate();
 	GEngine.reset();
 
+	SCAR_LOG(LogInfo, "Terminating");
+
 	return 0;
 }

--- a/ScarletEditor/src/Panels/OutputLog.cpp
+++ b/ScarletEditor/src/Panels/OutputLog.cpp
@@ -1,0 +1,122 @@
+#include "Panels/OutputLog.h"
+
+namespace ScarletEngine
+{
+	OutputLogPanel::OutputLogPanel()
+		: FilterText()
+		, CurrentMessageIndex(0)
+		, NumMessages(0)
+	{
+		
+		MessageBuffer.resize(MaxBufferLength);
+		FilterText.reserve(32);
+
+		Logger::Get().GetOnMessageLogged().Bind(this, &OutputLogPanel::OnMessageLogged);
+	}
+
+	OutputLogPanel::~OutputLogPanel()
+	{
+		Logger::Get().GetOnMessageLogged().Unbind(this);
+	}
+
+	void OutputLogPanel::Draw()
+	{
+		if (ImGui::Begin("Output Log"))
+		{
+			ImGui::TextUnformatted(ICON_MD_FILTER_LIST " Filter:");
+			ImGui::SameLine();
+			ImGui::InputText("###Filter", (char*)FilterText.c_str(), FilterText.capacity(), ImGuiInputTextFlags_EnterReturnsTrue);
+			
+			ImGui::SameLine();
+
+			if (ImGui::Button("Clear"))
+			{
+				Clear();
+			}
+			ImGui::SameLine();
+
+			if (ImGui::Button(ICON_MD_SETTINGS))
+			{
+				ImGui::OpenPopup("###OutputSetting");
+			}
+
+			if (ImGui::BeginPopup("###OutputSetting"))
+			{
+				ImGui::MenuItem("Show Verbose", "", &bShowVerbose);
+				ImGui::MenuItem("Show Info", "", &bShowInfo);
+				ImGui::MenuItem("Show Warning", "", &bShowWarning);
+				ImGui::MenuItem("Show Error", "", &bShowError);
+				ImGui::Separator();
+				ImGui::MenuItem("Autoscroll", "", &bAutoscroll);
+				ImGui::EndPopup();
+			}
+
+			if (ImGui::BeginChild("Log"))
+			{
+				uint32_t i = (CurrentMessageIndex) % ((NumMessages < MaxBufferLength) && (NumMessages != 0) ? NumMessages : MaxBufferLength);
+				uint32_t UpdateCount = 0;
+				while (UpdateCount < NumMessages)
+				{
+					Message& Msg = MessageBuffer[i];
+					if (((Msg.Severity == LogLevel::LogVerbose && bShowVerbose) || 
+							(Msg.Severity == LogLevel::LogInfo && bShowInfo) ||
+							(Msg.Severity == LogLevel::LogWarning && bShowWarning) ||
+							(Msg.Severity == LogLevel::LogError && bShowError)) &&
+						PassesFilter(Msg.Text))
+					{
+						switch (Msg.Severity)
+						{
+						case LogLevel::LogInfo:
+							ImGui::TextUnformatted(Msg.Text.c_str());
+							break;
+						case LogLevel::LogVerbose:
+							ImGui::TextDisabled("%s", Msg.Text.c_str());
+							break;
+						case LogLevel::LogWarning:
+							ImGui::TextColored(ImVec4(1.0f, 1.0f, 0.0f, 1.0f),"%s", Msg.Text.c_str());
+							break;
+						case LogLevel::LogError:
+							ImGui::TextColored(ImVec4(1.0f, 0.2f, 0.2f, 1.0f), "%s", Msg.Text.c_str());
+							break;
+						}
+					}
+
+					i = (i + 1) % MaxBufferLength;
+					UpdateCount++;
+				}
+
+				// If there was a new message, scroll to the end of the child window
+				if (bHasNewMessage && bAutoscroll)
+				{
+					ImGui::SetScrollHereY(1.0f);
+					bHasNewMessage = false;
+				}
+			}
+			
+			ImGui::EndChild();
+		}
+		ImGui::End();
+	}
+
+	bool OutputLogPanel::PassesFilter(const String& Msg) const
+	{
+		return Msg.find(FilterText.c_str()) != std::string::npos;
+	}
+
+	void OutputLogPanel::OnMessageLogged(LogLevel Level, const char* Msg)
+	{
+		MessageBuffer[CurrentMessageIndex] = { Msg, Level };
+		CurrentMessageIndex = (CurrentMessageIndex + 1) % MaxBufferLength;
+		if (NumMessages != MaxBufferLength)
+		{
+			++NumMessages;
+		}
+		bHasNewMessage = true;
+	}
+
+	void OutputLogPanel::Clear()
+	{
+		CurrentMessageIndex = 0;
+		NumMessages = 0;
+	}
+}

--- a/ScarletEngine/include/Core/CoreMinimal.h
+++ b/ScarletEngine/include/Core/CoreMinimal.h
@@ -4,53 +4,6 @@
 
 #include "CorePCH.h"
 #include "CoreUtils.h"
+#include "CoreSTL.h"
 #include "Logger.h"
 #include "Memory/Memory.h"
-
-namespace ScarletEngine
-{
-	using byte_t = uint8_t;
-
-	template <typename T, typename Alloc = GlobalAllocator<T>>
-	using Array = std::vector<T, Alloc>;
-
-	template <typename T, size_t Size>
-	using StaticArray = std::array<T, Size>;
-
-	template <typename Key, typename Val, typename Pred = std::less<Key>, typename Alloc = GlobalAllocator<std::pair<const Key, Val>>>
-	using Map = std::map<Key, Val, Pred, Alloc>;
-
-	template <typename Key, typename Val, typename Hash = std::hash<Key>, typename KeyCmp = std::equal_to<Key>, typename Alloc = GlobalAllocator<std::pair<const Key, Val>>>
-	using UnorderedMap = std::unordered_map<Key, Val, Hash, KeyCmp, Alloc>;
-
-	template <typename Key, typename KeyCmp = std::less<Key>, typename Alloc = GlobalAllocator<Key >>
-	using Set = std::set<Key, KeyCmp, Alloc>;
-
-	template <typename Key, typename KeyCmp = std::equal_to<Key>, typename Alloc = GlobalAllocator<Key>>
-	using UnorderedSet = std::unordered_set<Key, KeyCmp, Alloc>;
-
-	template <typename CharType = char, typename Traits = std::char_traits<CharType>, typename Alloc = GlobalAllocator<CharType>>
-	using BasicString = std::basic_string<CharType, Traits, Alloc>;
-
-	using String = BasicString<char>;
-}
-
-
-// Inject some template specializations into the std namespace for our custom stl types
-namespace std
-{
-	// This is only needed in non-msvc builds
-#ifndef _MSC_VER
-	template <class Elem, class Traits, class Alloc>
-	struct hash<ScarletEngine::BasicString<Elem, Traits, Alloc>>
-	{
-		using argument_type = ScarletEngine::BasicString<Elem, Traits, Alloc>;
-		using result_type = size_t;
-
-		[[nodiscard]] size_t operator()(const ScarletEngine::BasicString<Elem, Traits, Alloc>& Keyval) const
-		{
-			return std::hash<std::string_view>{}(Keyval.c_str());
-		}
-	};
-#endif
-}

--- a/ScarletEngine/include/Core/CoreSTL.h
+++ b/ScarletEngine/include/Core/CoreSTL.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "CorePCH.h"
+#include "Memory/Memory.h"
+
+namespace ScarletEngine
+{
+	using byte_t = uint8_t;
+
+	template <typename T, typename Alloc = GlobalAllocator<T>>
+	using Array = std::vector<T, Alloc>;
+
+	template <typename T, size_t Size>
+	using StaticArray = std::array<T, Size>;
+
+	template <typename Key, typename Val, typename Pred = std::less<Key>, typename Alloc = GlobalAllocator<std::pair<const Key, Val>>>
+	using Map = std::map<Key, Val, Pred, Alloc>;
+
+	template <typename Key, typename Val, typename Hash = std::hash<Key>, typename KeyCmp = std::equal_to<Key>, typename Alloc = GlobalAllocator<std::pair<const Key, Val>>>
+	using UnorderedMap = std::unordered_map<Key, Val, Hash, KeyCmp, Alloc>;
+
+	template <typename Key, typename KeyCmp = std::less<Key>, typename Alloc = GlobalAllocator<Key >>
+	using Set = std::set<Key, KeyCmp, Alloc>;
+
+	template <typename Key, typename KeyCmp = std::equal_to<Key>, typename Alloc = GlobalAllocator<Key>>
+	using UnorderedSet = std::unordered_set<Key, KeyCmp, Alloc>;
+
+	template <typename CharType = char, typename Traits = std::char_traits<CharType>, typename Alloc = GlobalAllocator<CharType>>
+	using BasicString = std::basic_string<CharType, Traits, Alloc>;
+
+	using String = BasicString<char>;
+}
+
+
+// Inject some template specializations into the std namespace for our custom stl types
+namespace std
+{
+	// This is only needed in non-msvc builds
+#ifndef _MSC_VER
+	template <class Elem, class Traits, class Alloc>
+	struct hash<ScarletEngine::BasicString<Elem, Traits, Alloc>>
+	{
+		using argument_type = ScarletEngine::BasicString<Elem, Traits, Alloc>;
+		using result_type = size_t;
+
+		[[nodiscard]] size_t operator()(const ScarletEngine::BasicString<Elem, Traits, Alloc>& Keyval) const
+		{
+			return std::hash<std::string_view>{}(Keyval.c_str());
+		}
+	};
+#endif
+}

--- a/ScarletEngine/include/Core/Delegate.h
+++ b/ScarletEngine/include/Core/Delegate.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "Core/CoreMinimal.h"
+#include "Core/CorePCH.h"
 
 namespace ScarletEngine
 {

--- a/ScarletEngine/include/Core/Logger.h
+++ b/ScarletEngine/include/Core/Logger.h
@@ -26,8 +26,12 @@ namespace ScarletEngine
 
 		const OnMessageLoggedEvent& GetOnMessageLogged() const { return OnMessageLogged; }
 
-		~Logger();
 	private:
+		Logger() = default;
+		Logger(const Logger&) = delete;
+		Logger(Logger&&) = delete;
+		~Logger();
+
 		FILE* LogFile = nullptr;
 		OnMessageLoggedEvent OnMessageLogged;
 	};

--- a/ScarletEngine/include/Core/Logger.h
+++ b/ScarletEngine/include/Core/Logger.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdio>
+#include "Event.h"
 
 namespace ScarletEngine
 {
@@ -12,18 +13,23 @@ namespace ScarletEngine
 		LogError
 	};
 
+	using OnMessageLoggedEvent = Event<LogLevel, const char*>;
+
 	class Logger
 	{
 	public:
-		void Log(LogLevel Level, const char* Message) const;
+		void Log(LogLevel Level, const char* Message);
 
 		void SetLogFile(const char* FilePath);
 
 		static Logger& Get() { static Logger Instance; return Instance; }
 
+		const OnMessageLoggedEvent& GetOnMessageLogged() const { return OnMessageLogged; }
+
 		~Logger();
 	private:
 		FILE* LogFile = nullptr;
+		OnMessageLoggedEvent OnMessageLogged;
 	};
 }
 

--- a/ScarletEngine/include/Core/Memory/Memory.h
+++ b/ScarletEngine/include/Core/Memory/Memory.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "MemoryTracker.h"
-#include <iostream>
 namespace ScarletEngine
 {
 	template <class T>
@@ -15,8 +14,9 @@ namespace ScarletEngine
 		using const_reference = const T&;
 		using value_type = T;
 
-		GlobalAllocator() = default;
-		template <class U> constexpr GlobalAllocator(const GlobalAllocator <U>&) {}
+		inline GlobalAllocator() = default;
+		inline GlobalAllocator(const GlobalAllocator&) {}
+		template <class U> inline GlobalAllocator(const GlobalAllocator<U>&) {}
 
 		[[nodiscard]] T* allocate(size_t Number) 
 		{
@@ -42,6 +42,9 @@ namespace ScarletEngine
 			return Ptr;
 		}
 	
+		inline bool operator==(const GlobalAllocator&) { return true; }
+		inline bool operator!=(const GlobalAllocator&) { return true; }
+
 		struct Delete
 		{
 			void operator()(T* Ptr)

--- a/ScarletEngine/include/Core/Memory/MemoryTracker.h
+++ b/ScarletEngine/include/Core/Memory/MemoryTracker.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Core/CoreUtils.h"
-#include "Core/Logger.h"
 #include "Core/CorePCH.h"
 
 namespace ScarletEngine

--- a/ScarletEngine/src/Core/ITickable.cpp
+++ b/ScarletEngine/src/Core/ITickable.cpp
@@ -1,5 +1,4 @@
 #include "Core/ITickable.h"
-#include "Core/CoreUtils.h"
 #include "Core/Engine.h"
 
 namespace ScarletEngine

--- a/ScarletEngine/src/Core/Logger.cpp
+++ b/ScarletEngine/src/Core/Logger.cpp
@@ -18,7 +18,7 @@ namespace ScarletEngine
 		}
 	}
 
-	void Logger::Log(LogLevel Level, const char* Message) const
+	void Logger::Log(LogLevel Level, const char* Message)
 	{
 		static const char* VerbosePrefix = "[Verbose]";
 		static const char* InfoPrefix = "[Info]";
@@ -65,6 +65,13 @@ namespace ScarletEngine
 		{
 			fprintf(LogFile, "%s %s %s\n", TimeStringBuffer, *PrefixPtr, Message);
 		}
+
+		strftime(TimeStringBuffer, sizeof(TimeStringBuffer), "[%X]", TimeStruct);
+
+		char Buffer[4096];
+		snprintf(Buffer, 4096, "%s %s %s\n", TimeStringBuffer , *PrefixPtr, Message);
+
+		OnMessageLogged.Broadcast(Level, Buffer);
 	}
 
 	void Logger::SetLogFile(const char* FilePath)


### PR DESCRIPTION
The editor can now display the output of all SCAR_LOG macros. The window includes a filter box which allows users to display only messages which contain specific substrings.

Also includes a settings menu which can be used to toggle the verbosity of the displayed messages.

Closes #14 