### PR TITLE
Lowered OpenGL context version to 4.5

### DIFF
--- a/ScarletEngine/Sources/OpenGLRAL/Private/OpenGLRAL.cpp
+++ b/ScarletEngine/Sources/OpenGLRAL/Private/OpenGLRAL.cpp
@@ -82,7 +82,7 @@ namespace ScarletEngine
 		ZoneScoped
 		glfwInit();
 		glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 6);
+		glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 5);
 		glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 		glfwWindowHint(GLFW_SAMPLES, 4);
 #ifdef DEBUG


### PR DESCRIPTION
Not necessary to have the absolute latest version and causes incompatibility with older hardware.