### PR TITLE
Module initialization no longer static

### DIFF
--- a/ScarletEditor/CMakeLists.txt
+++ b/ScarletEditor/CMakeLists.txt
@@ -54,7 +54,7 @@ file(GLOB ScarletEditor_SRC "Sources/EditorMain.cpp")
 add_executable(ScarletEditor ${ScarletEditor_SRC})
 
 get_property(ScarletEditorModules GLOBAL PROPERTY ScarletEditorModulesProperty)
-target_link_libraries(ScarletEditor PRIVATE "Engine" ${ScarletEditorModules})
+target_link_libraries(ScarletEditor PRIVATE Engine UI ${ScarletEditorModules})
 
 target_include_directories(ScarletEditor PUBLIC "include")
 target_compile_features(ScarletEditor PUBLIC cxx_std_20)

--- a/ScarletEditor/Sources/EditorMain.cpp
+++ b/ScarletEditor/Sources/EditorMain.cpp
@@ -4,6 +4,8 @@
 #include "RAL.h"
 #include "StaticMeshComponent.h"
 #include "AssetManager.h"
+#include "RenderModule.h"
+#include "UIModule.h"
 
 int main()
 {
@@ -11,6 +13,9 @@ int main()
 	
 	// #todo_Core: this should be loaded by a config file or something, for now default it to this.
 	AssetManager::SetAssetRoot("../");
+
+	ModuleManager::GetInstance().RegisterModule<RenderModule>();
+	ModuleManager::GetInstance().RegisterModule<UIModule>();
 
 	GEngine = MakeUnique<Engine>();
 	GEngine->Initialize();

--- a/ScarletEngine/Sources/Core/Private/IModule.cpp
+++ b/ScarletEngine/Sources/Core/Private/IModule.cpp
@@ -1,14 +1,7 @@
 #include "IModule.h"
 
-#include "ModuleManager.h"
-
 namespace ScarletEngine
 {
-	IModule::IModule()
-	{
-		ModuleManager::RegisterModule(this);
-	}
-
 	void IModule::Initialize()
 	{
 		Startup();

--- a/ScarletEngine/Sources/Core/Public/IModule.h
+++ b/ScarletEngine/Sources/Core/Public/IModule.h
@@ -13,7 +13,7 @@ namespace ScarletEngine
 	class IModule
 	{
 	public:
-		IModule();
+		virtual ~IModule() {}
 
 		virtual void Startup() = 0;
 		virtual void Shutdown() = 0;

--- a/ScarletEngine/Sources/Engine/Private/Engine.cpp
+++ b/ScarletEngine/Sources/Engine/Private/Engine.cpp
@@ -36,7 +36,7 @@ namespace ScarletEngine
 
 		AppWindow->OnWindowClose.BindMember(this, &Engine::SignalQuit);
 
-		ModuleManager::Startup();
+		ModuleManager::GetInstance().Startup();
 
 		bIsInitialized = true;
 	}
@@ -85,7 +85,7 @@ namespace ScarletEngine
 	{
 		ZoneScoped
 		AddQueuedTickables();
-		ModuleManager::PreUpdate();
+		ModuleManager::GetInstance().PreUpdate();
 
 		AppWindow->PollEvents();
 	}
@@ -93,7 +93,7 @@ namespace ScarletEngine
 	void Engine::PostUpdate()
 	{
 		ZoneScoped
-		ModuleManager::PostUpdate();
+		ModuleManager::GetInstance().PostUpdate();
 
 		AppWindow->SwapBuffer();
 	}
@@ -101,7 +101,7 @@ namespace ScarletEngine
 	void Engine::Terminate()
 	{
 		ZoneScoped
-		ModuleManager::Shutdown();
+		ModuleManager::GetInstance().Shutdown();
 
 		ScarDelete(AppWindow);
 
@@ -115,7 +115,7 @@ namespace ScarletEngine
 	void Engine::Update(double DeltaTime)
 	{
 		ZoneScoped
-		ModuleManager::Update();
+		ModuleManager::GetInstance().Update();
 		for (const auto Tickable : VariableUpdateTickables)
 		{
 			Tickable->Tick(DeltaTime);

--- a/ScarletEngine/Sources/Renderer/Private/RenderModule.cpp
+++ b/ScarletEngine/Sources/Renderer/Private/RenderModule.cpp
@@ -29,6 +29,8 @@ namespace ScarletEngine
 	void RenderModule::Shutdown()
 	{
 		RAL::Get().Terminate();
+		RAL::Instance.reset();
+		RAL::API = RenderAPI::Invalid;
 	}
 
 
@@ -65,6 +67,4 @@ namespace ScarletEngine
 		
 		ActiveViewport->Unbind();
 	}
-
-	DECLARE_MODULE(RenderModule);
 }

--- a/ScarletEngine/Sources/Renderer/Public/SceneProxy.h
+++ b/ScarletEngine/Sources/Renderer/Public/SceneProxy.h
@@ -2,6 +2,7 @@
 
 #include "Core.h"
 #include "StaticMeshComponent.h"
+#include "RenderModule.h"
 
 namespace ScarletEngine
 {

--- a/ScarletEngine/Sources/UI/Private/UIModule.cpp
+++ b/ScarletEngine/Sources/UI/Private/UIModule.cpp
@@ -174,6 +174,4 @@ namespace ScarletEngine
 		ActiveLayer = InLayer;
 		ActiveLayer->Initialize();
 	}
-
-	DECLARE_MODULE(UIModule);
 }

--- a/TestGame/TestMain.cpp
+++ b/TestGame/TestMain.cpp
@@ -1,18 +1,29 @@
-#include "Core.h"
 #include "Engine.h"
+#include "AssetManager.h"
 #include "World.h"
-#include "ECS.h"
+#include "RAL.h"
+#include "ModuleManager.h"
+#include "RenderModule.h"
 
 int main()
 {
 	using namespace ScarletEngine;
-	GEngine = MakeUnique<Engine>();
+
+	// #todo_Core: this should be loaded by a config file or something, for now default it to this.
+	AssetManager::SetAssetRoot("../");
+	
+	ModuleManager::RegisterModule<RenderModule>();
+
+	GEngine = MakeUnique<Engine>();	
 	GEngine->Initialize();
 
 	{
-		// If you need to test any runtime code outside of the editor environment,
-		// this is where you can put it.
+		SharedPtr<World> TestWorld = MakeShared<World>();
+		TestWorld->Initialize();
+
+		GEngine->Run();
 	}
+
 
 	GEngine->Terminate();
 	GEngine.reset();


### PR DESCRIPTION
In order to prevent ABI incompatibilities and simplify the code, module registration no longer happens during static initialization. Now requires manual registration.