### PR TITLE
Changed ITickable's destructor to virtual

### DIFF
--- a/ScarletEngine/Sources/Engine/Public/ITickable.h
+++ b/ScarletEngine/Sources/Engine/Public/ITickable.h
@@ -14,7 +14,7 @@ namespace ScarletEngine
 		ITickable();
 
 		/** Removes the object from the engine tickable list */
-		~ITickable();
+		virtual ~ITickable();
 
 		/** Called each frame by the Engine with the delta time since the last Tick. */
 		virtual void Tick(double /* DeltaTime */) {}


### PR DESCRIPTION
This is a big oof leading to tons of potential memory leaks and undefined behavior.

