### PR TITLE
Fixed issue with check in non-debug builds

### DIFF
--- a/ScarletEngine/Sources/Core/Public/CoreUtils.h
+++ b/ScarletEngine/Sources/Core/Public/CoreUtils.h
@@ -20,7 +20,7 @@
 	}				\
 }
 #else
-#define check(pred) (pred)
+#define check(pred) (void)(pred)
 #endif
 
 /** Define OUT as nothing, it is simply used to markup code to make it more readable */

--- a/ScarletEngine/Sources/Core/Public/CoreUtils.h
+++ b/ScarletEngine/Sources/Core/Public/CoreUtils.h
@@ -20,7 +20,7 @@
 	}				\
 }
 #else
-#define check(pred)
+#define check(pred) (pred)
 #endif
 
 /** Define OUT as nothing, it is simply used to markup code to make it more readable */


### PR DESCRIPTION
if an expression with side effects was passed to check in a non-debug build, it would fail to execute as the entire check macro would be removed. Instead we force the expression to be evaluated thereby causing all side effects to be executed. 