### PR TITLE
Fixed overlapping grid lines in editor viewport

### DIFF
--- a/ScarletEditor/Sources/Editor/Private/EditorViewport.cpp
+++ b/ScarletEditor/Sources/Editor/Private/EditorViewport.cpp
@@ -106,9 +106,6 @@ namespace ScarletEngine
 		ImGuizmo::SetDrawlist();
 		ImGuizmo::SetRect(ImGui::GetWindowPos().x, ImGui::GetWindowPos().y, PanelSize.x, PanelSize.y);
 
-		uint64_t TextureID = View->GetColorAttachmentID();
-		ImGui::Image(reinterpret_cast<void*>(TextureID), ImVec2{ PanelSize.x, PanelSize.y }, ImVec2{ 0, 1 }, ImVec2{ 1, 0 });
-
 		Camera& ViewportCamera = View->GetCamera();
 		glm::mat4 ViewMatrix = ViewportCamera.GetView();
 		glm::mat4 ProjMatrix = ViewportCamera.GetProj();
@@ -117,6 +114,9 @@ namespace ScarletEngine
 		{
 			ImGuizmo::DrawGrid(glm::value_ptr(ViewMatrix), glm::value_ptr(ProjMatrix), glm::value_ptr(glm::mat4(1.f)), 100.f);
 		}
+
+		const uint64_t TextureID = View->GetColorAttachmentID();
+		ImGui::Image(reinterpret_cast<void*>(TextureID), ImVec2{ PanelSize.x, PanelSize.y }, ImVec2{ 0, 1 }, ImVec2{ 1, 0 });
 
 		if (bShowCube)
 		{

--- a/ScarletEngine/Sources/OpenGLRAL/Private/OpenGLRAL.cpp
+++ b/ScarletEngine/Sources/OpenGLRAL/Private/OpenGLRAL.cpp
@@ -98,7 +98,7 @@ namespace ScarletEngine
 		}
 #endif
 
-		glClearColor(0.1f, 0.1f, 0.1f, 1.0f);
+		glClearColor(0.1f, 0.1f, 0.1f, 0.0f);
 		glFrontFace(GL_CCW);
 		glEnable(GL_DEPTH_TEST);
 		glEnable(GL_MULTISAMPLE);

--- a/ScarletEngine/Sources/Renderer/Private/RenderModule.cpp
+++ b/ScarletEngine/Sources/Renderer/Private/RenderModule.cpp
@@ -54,7 +54,6 @@ namespace ScarletEngine
 		if (Scene && ActiveViewport)
 		{
 			ActiveViewport->Bind();
-			RAL::Get().SetClearColorCommand({ 0.1f, 0.1f, 0.1f, 1.f });
 			RAL::Get().ClearCommand(true, true, true);
 
 			ActiveViewport->Bind();


### PR DESCRIPTION
Draws are now transparent except where objects are. This is a hacky fix for #96 but it will do for now.