### PR TITLE
Cache ECS proxies

### DIFF
--- a/ScarletEngine/Sources/Core/Public/CoreSTL.h
+++ b/ScarletEngine/Sources/Core/Public/CoreSTL.h
@@ -22,8 +22,8 @@ namespace ScarletEngine
 	template <typename Key, typename KeyCmp = std::less<Key>, typename Alloc = GlobalAllocator<Key >>
 	using Set = std::set<Key, KeyCmp, Alloc>;
 
-	template <typename Key, typename KeyCmp = std::equal_to<Key>, typename Alloc = GlobalAllocator<Key>>
-	using UnorderedSet = std::unordered_set<Key, KeyCmp, Alloc>;
+	template <typename Key, typename KeyHash = std::hash<Key>, typename KeyEq = std::equal_to<Key>, typename Alloc = GlobalAllocator<Key>>
+	using UnorderedSet = std::unordered_set<Key, KeyHash, KeyEq, Alloc>;
 
 	template <typename T, typename Alloc = GlobalAllocator<T>>
 	using Deque = std::deque<T, Alloc>;

--- a/ScarletEngine/Sources/ECS/Public/System.h
+++ b/ScarletEngine/Sources/ECS/Public/System.h
@@ -22,7 +22,7 @@ namespace ScarletEngine
 		virtual void FixedUpdate() const {}
 
 		template <typename ...Components>
-		Array<ProxyType<Components...>> GetEntities() const
+		const Array<ProxyType<Components...>>& GetEntities() const
 		{
 			return Reg->GetProxies<Components...>();
 		}


### PR DESCRIPTION
Caching ECS proxies allows for major performance improvements as creating proxies is currently very slow.

<img width="438" alt="cache-proxies-unorderedmap" src="https://user-images.githubusercontent.com/25555412/114456033-65d2ee00-9baa-11eb-83da-92db9364f434.png">
